### PR TITLE
fix build failue in app-shells/fish-shell

### DIFF
--- a/packages/app-shells/fish-shell/fish-shell-scm.exheres-0
+++ b/packages/app-shells/fish-shell/fish-shell-scm.exheres-0
@@ -11,9 +11,3 @@ DEPENDENCIES="
       sys-libs/ncurses
 "
 
-src_install() {
-    default
-
-    edo rmdir "${IMAGE}"/usr/share/{fish/,}man/{man1/,}
-}
-


### PR DESCRIPTION
Fixes this error

```
  * In program cave perform install --hooks --managed-output --output-exclusivity with-others =app-shells/fish-shell-scm:0::nicoo --destination installed --replacing =app-shells/fish-shell-scm:0::installed --x-of-y 3 of 6:
  * When installing 'app-shells/fish-shell-scm:0::nicoo' replacing { 'app-shells/fish-shell-scm:0::installed' }:
  * When running an ebuild command on 'app-shells/fish-shell-scm:0::nicoo':
  * Install failed for 'app-shells/fish-shell-scm:0::nicoo' (paludis::ActionFailedError)

Installed docs README.md CHANGELOG history.cpp history.h history.o release_notes.html
rmdir /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/man1/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/man1/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/
rmdir: failed to remove '/var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/man1/': Directory not empty
rmdir: failed to remove '/var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/': Directory not empty
rmdir: failed to remove '/var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/man1/': Directory not empty
rmdir: failed to remove '/var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/': Directory not empty

!!! ERROR in app-shells/fish-shell-scm::nicoo:
!!! In edo at line 1435
!!! rmdir /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/man1/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/fish/man/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/man1/ /var/tmp/paludis/build/app-shells-fish-shell-scm/image//usr/share/man/ failed

!!! Call stack:
!!!    * paludis_die_unless_nonfatal_func (/var/tmp/paludis/build/app-shells-fish-shell-scm/temp/loadsaveenv:2377)
!!!    * edo (/var/tmp/paludis/build/app-shells-fish-shell-scm/temp/loadsaveenv:1435)
!!!    * src_install (/var/tmp/paludis/build/app-shells-fish-shell-scm/temp/loadsaveenv:3314)
!!!    * exheres_internal_install (/usr/libexec/paludis/exheres-0/src_install.bash:54)
!!!    * ebuild_main (/usr/libexec/paludis/ebuild.bash:673)
!!!    * main (/usr/libexec/paludis/ebuild.bash:696)
```
