### PR TITLE
fix failure to build corkscrew

### DIFF
--- a/packages/net-proxy/corkscrew/corkscrew-2.0.exheres-0
+++ b/packages/net-proxy/corkscrew/corkscrew-2.0.exheres-0
@@ -10,5 +10,5 @@ LICENCES="GPL-2"
 SLOT="0"
 PLATFORMS="~amd64"
 
-DEFAULT_SRC_CONFIGURE_PARAMS=( --hates=docdir )
+DEFAULT_SRC_CONFIGURE_PARAMS=( --hates=docdir --hates=datarootdir )
 


### PR DESCRIPTION
Hi,

I failed to build corkscrew with following configure error, this patch could fix:

=== Starting src_configure
econf: updating /var/tmp/paludis/build/net-proxy-corkscrew-2.0/work/corkscrew-2.0/config.guess with /usr/share/gnuconfig/config.guess
econf: updating /var/tmp/paludis/build/net-proxy-corkscrew-2.0/work/corkscrew-2.0/config.sub with /usr/share/gnuconfig/config.sub
./configure --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --prefix=/usr/x86_64-pc-linux-gnu --bindir=/usr/x86_64-pc-linux-gnu/bin --sbindir=/usr/x86_64-pc-linux-gnu/bin --libdir=/usr/x
86_64-pc-linux-gnu/lib --datadir=/usr/share --datarootdir=/usr/share --infodir=/usr/share/info --mandir=/usr/share/man --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking -
-disable-silent-rules --enable-fast-install
configure: error: --datarootdir=/usr/share: invalid option; use --help to show usage

!!! ERROR in net-proxy/corkscrew-2.0::nicoo:
!!! In econf at line 1199
!!! econf failed